### PR TITLE
keep embed.go in static folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,7 @@ npm-debug.log
 yarn-error.log
 /.idea
 /.vscode
+
+# ignore static generated folder but keep embed.go
+static/**
+!static/embed.go

--- a/static/embed.go
+++ b/static/embed.go
@@ -1,0 +1,7 @@
+package static
+
+import "embed"
+
+// Files embed.
+//go:embed *
+var Files embed.FS


### PR DESCRIPTION
Hey there, nice example.

The `embed.go` is missing after cloning and needs to be added manually.
I just added it and updated the gitignore to include only this file from the `static` folder.

You could also just use a `.gitkeep` probably. Like to do it this way.